### PR TITLE
Reconcile formats

### DIFF
--- a/format.php
+++ b/format.php
@@ -1,0 +1,74 @@
+<?php
+class Format {
+    public $shared_id_bigint;
+    public $key_string;
+    public $worldid_mixed;
+    public $lang_enum;
+    public $name_string;
+    public $description_string;
+    public $format_type_enum;
+
+    public function __construct($shared_id_bigint, $key_string, $worldid_mixed, $lang_enum, $name_string, $description_string, $format_type_enum) {
+        $this->shared_id_bigint = $shared_id_bigint;
+        $this->key_string = $key_string;
+        $this->worldid_mixed = $worldid_mixed;
+        $this->lang_enum = $lang_enum;
+        $this->name_string = $name_string;
+        $this->description_string = $description_string;
+        $this->format_type_enum = $format_type_enum;
+    }
+
+    public function is_exact_match($other) {
+        if ($this->key_string != $other->key_string) {
+            return false;
+        }
+        if ($this->name_string != $other->name_string) {
+            return false;
+        }
+        if ($this->lang_enum != $other->lang_enum) {
+            return false;
+        }
+        if ($this->format_type_enum != $other->format_type_enum) {
+            return false;
+        }
+        if ($this->description_string != $other->description_string) {
+            return false;
+        }
+        if ($this->worldid_mixed != $other->worldid_mixed) {
+            return false;
+        }
+        return true;
+    }
+
+    public function is_match($other) {
+        if ($this->is_exact_match($other)) {
+            return true;
+        }
+        if (strtoupper($this->key_string) != strtoupper($other->key_string)) {
+            return false;
+        }
+        if (strtoupper($this->name_string) != strtoupper($other->name_string)) {
+            return false;
+        }
+        if ($this->lang_enum != $other->lang_enum) {
+            return false;
+        }
+        return true;
+    }
+
+    public function getInsertStatement($table_prefix, $next_id) {
+        $table_name = $table_prefix . "comdef_formats";
+        $sql  = "INSERT INTO " . $table_name . " ";
+        $sql .= "(shared_id_bigint, key_string, worldid_mixed, lang_enum, name_string, description_string, format_type_enum) ";
+        $sql .= "VALUES (";
+        $sql .= "'" . strval($next_id) . "', ";
+        $sql .= "'" . strval($this->key_string) . "', ";
+        $sql .= "'" . strval($this->worldid_mixed) . "', ";
+        $sql .= "'" . strval($this->lang_enum) . "', ";
+        $sql .= "'" . strval($this->name_string) . "', ";
+        $sql .= "'" . strval($this->description_string) . "', ";
+        $sql .= "'" . strval($this->format_type_enum) . "' ";
+        $sql .= ")";
+        return $sql;
+    }
+}

--- a/format.php
+++ b/format.php
@@ -60,15 +60,16 @@ class Format {
         $table_name = $table_prefix . "comdef_formats";
         $sql  = "INSERT INTO " . $table_name . " ";
         $sql .= "(shared_id_bigint, key_string, worldid_mixed, lang_enum, name_string, description_string, format_type_enum) ";
-        $sql .= "VALUES (";
-        $sql .= "'" . strval($next_id) . "', ";
-        $sql .= "'" . strval($this->key_string) . "', ";
-        $sql .= "'" . strval($this->worldid_mixed) . "', ";
-        $sql .= "'" . strval($this->lang_enum) . "', ";
-        $sql .= "'" . strval($this->name_string) . "', ";
-        $sql .= "'" . strval($this->description_string) . "', ";
-        $sql .= "'" . strval($this->format_type_enum) . "' ";
-        $sql .= ")";
-        return $sql;
+        $sql .= "VALUES (?, ?, ?, ?, ?, ?, ?)";
+        $params = array(
+            strval($next_id) ,
+            strval($this->key_string),
+            strval($this->worldid_mixed),
+            strval($this->lang_enum),
+            strval($this->name_string),
+            strval($this->description_string),
+            strval($this->format_type_enum)
+        );
+        return array($sql, $params);
     }
 }

--- a/functions.php
+++ b/functions.php
@@ -164,9 +164,9 @@ function anySourceMeetingsUsingFormat($id) {
 }
 
 function targetHasFormatIdWithLanguage($shared_id_bigint, $lang_enum) {
-    $table_name = $GLOBALS["source_table_prefix"] . "comdef_formats";
+    $table_name = $GLOBALS["target_table_prefix"] . "comdef_formats";
     $query = "SELECT COUNT(*) as `count` FROM " . $table_name . " WHERE shared_id_bigint = '". $shared_id_bigint . "' AND lang_enum = '" . $lang_enum ."'";
-    $result = executeSourceScalarValue($query);
+    $result = executeTargetScalarValue($query);
     return (intval($result->count) > 0);
 }
 

--- a/functions.php
+++ b/functions.php
@@ -245,6 +245,7 @@ function getSourceLanguages() {
     }
     return $languages;
 }
+
 function reconcileFormats() {
     $languages = getSourceLanguages();
     unset($languages[array_search("en", $languages)]);

--- a/functions.php
+++ b/functions.php
@@ -179,10 +179,15 @@ function reconcileFormatsForLanguage($lang_enum, $mapping=null) {
     $target_formats = getTargetFormats($lang_enum);
 
     foreach ($source_formats as $source_format) {
+        // If the format isn't used at all, we don't bother importing it
         if (!anySourceMeetingsUsingFormat($source_format->shared_id_bigint)) {
             continue;
         }
+        
         $found_match = false;
+
+        // Has a previous pass already mapped this format? If so, we make sure this translation of the format exists in the target,
+        // and if it doesn't, we create it.
         if (array_key_exists($source_format->shared_id_bigint, $mapping)) {
             $existingId = $mapping[$source_format->shared_id_bigint];
             $existingId = $existingId[0]["shared_id_bigint"];


### PR DESCRIPTION
This works is being tested with the  `NNERNA -> NERNA` merge. It prints out its results, and will fail if a required format does not exist when inserting the meetings. Formats that are not used by a meeting are not copied to the target database.

Example output:

```
Found exact format match: source format 'B:1' to target format 'B:1'.
Found exact format match: source format 'BT:3' to target format 'BT:3'.
Found exact format match: source format 'C:4' to target format 'C:4'.
Found exact format match: source format 'D:8' to target format 'D:8'.
Found exact format match: source format 'IP:12' to target format 'IP:12'.
Found exact format match: source format 'IW:13' to target format 'IW:13'.
Found exact format match: source format 'JT:14' to target format 'JT:14'.
Found exact format match: source format 'M:15' to target format 'M:15'.
Found exact format match: source format 'O:17' to target format 'O:17'.
Found exact format match: source format 'RF:19' to target format 'RF:19'.
No match found for source format 'SD:22', creating target format 'SD:57'
Found exact format match: source format 'SG:23' to target format 'SG:23'.
Found exact format match: source format 'St:27' to target format 'St:27'.
Found exact format match: source format 'To:29' to target format 'To:29'.
Found exact format match: source format 'Tr:30' to target format 'Tr:30'.
Found exact format match: source format 'W:32' to target format 'W:32'.
Found exact format match: source format 'WC:33' to target format 'WC:33'.
Found exact format match: source format 'YP:34' to target format 'YP:34'.
Found exact format match: source format 'ME:41' to target format 'ME:41'.
Found exact format match: source format 'CW:44' to target format 'CW:44'.
No match found for source format 'WEB:50', creating target format 'WEB:57'
Found partial format match: source format 'LC:51' to target format 'LC:51'.
Found exact format match: source format 'VM:52' to target format 'VM:50'.
Found partial format match: source format 'TC:53' to target format 'TC:54'.
Found partial format match: source format '19:54' to target format '19:56'.
Found partial format match: source format 'HY:55' to target format 'HY:55'.
```